### PR TITLE
Fix ownership button relabeling by precomputing flags (fixes #97)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Fixed
 
+- Collection-related buttons now display appropriate add/modify labels, reflecting actual collection status.
 - Empty list messages for people/series have been corrected (they previously said "items" instead of appropriate entity types).
 
 ## 2.10.0 - 2025-12-28

--- a/module/GeebyDeeby/src/GeebyDeebyTest/Integration/MinkTestCase.php
+++ b/module/GeebyDeeby/src/GeebyDeebyTest/Integration/MinkTestCase.php
@@ -73,6 +73,20 @@ abstract class MinkTestCase extends \PHPUnit\Framework\TestCase
     }
 
     /**
+     * Go to the specified Geeby-Deeby page.
+     *
+     * @param string $path Path to load.
+     *
+     * @return TraversableElement
+     */
+    protected function goToPage(string $path = ''): TraversableElement
+    {
+        $session = $this->getMinkSession();
+        $session->visit($this->getGeebyDeebyUrl($path));
+        return $session->getPage();
+    }
+
+    /**
      * Sleep if necessary.
      *
      * @param int $secs Seconds to sleep

--- a/module/GeebyDeeby/tests/integration-tests/src/GeebyDeebyTest/Mink/IntegrationTest.php
+++ b/module/GeebyDeeby/tests/integration-tests/src/GeebyDeebyTest/Mink/IntegrationTest.php
@@ -103,9 +103,7 @@ class IntegrationTest extends MinkTestCase
     #[\PHPUnit\Framework\Attributes\DataProvider('emptyDatabaseProvider')]
     public function testEmptyDatabase(string $linkText, string $expectedMessage, ?int $containerIndex = null): void
     {
-        $session = $this->getMinkSession();
-        $session->visit($this->getGeebyDeebyUrl());
-        $page = $session->getPage();
+        $page = $this->goToPage();
         $target = $containerIndex === null ? $page : $this->findCss($page, 'p', index: $containerIndex);
         $target->clickLink($linkText);
         $this->assertStringEndsWith($expectedMessage, $this->findCssAndGetText($page, '.content'));
@@ -206,10 +204,7 @@ class IntegrationTest extends MinkTestCase
     #[\PHPUnit\Framework\Attributes\DataProvider('createUserProvider')]
     public function testCreateUser(string $username): void
     {
-        $session = $this->getMinkSession();
-        $session->visit($this->getGeebyDeebyUrl());
-        $page = $session->getPage();
-        $this->createUser($page, $username);
+        $this->createUser($this->goToPage(), $username);
     }
 
     /**
@@ -235,9 +230,7 @@ class IntegrationTest extends MinkTestCase
     #[\PHPUnit\Framework\Attributes\DataProvider('userApprovalProvider')]
     public function testUserApproval(string $username, ?int $group = null): void
     {
-        $session = $this->getMinkSession();
-        $session->visit($this->getGeebyDeebyUrl());
-        $page = $session->getPage();
+        $page = $this->goToPage();
 
         // Try to log in and confirm that the user exists but is not approved yet:
         $this->logIn($page, $username);
@@ -247,16 +240,16 @@ class IntegrationTest extends MinkTestCase
         $this->approveUser($username, $group);
 
         // Now go to the edit page and assert appropriate behavior (admin available if in group 1, not otherwise):
-        $session->visit($this->getGeebyDeebyUrl('/edit'));
-        $this->logIn($page, $username);
-        $this->assertEquals('Administration', $this->findCssAndGetText($page, 'h1'));
+        $nextPage = $this->goToPage('/edit');
+        $this->logIn($nextPage, $username);
+        $this->assertEquals('Administration', $this->findCssAndGetText($nextPage, 'h1'));
         if ($group === 1) {
-            $this->assertEquals('Edit Data', $this->findCssAndGetText($page, '.content h2'));
+            $this->assertEquals('Edit Data', $this->findCssAndGetText($nextPage, '.content h2'));
         } else {
-            $this->assertNotEquals('Edit Data', $this->findCssAndGetText($page, '.content h2'));
+            $this->assertNotEquals('Edit Data', $this->findCssAndGetText($nextPage, '.content h2'));
             $this->assertEquals(
                 'You do not have permission to access this page.',
-                $this->findCssAndGetText($page, '.content p')
+                $this->findCssAndGetText($nextPage, '.content p')
             );
         }
     }
@@ -476,12 +469,9 @@ class IntegrationTest extends MinkTestCase
         ?string $expectedDisplay = null,
         int $expectedLinkCount = 1
     ): void {
-        $session = $this->getMinkSession();
-        $session->visit($this->getGeebyDeebyUrl("/edit/$url"));
-        $page = $session->getPage();
+        $page = $this->goToPage("/edit/$url");
         $this->logIn($page, 'admin');
         $this->clickCss($page, $buttonSelector);
-        $firstValue = null;
         foreach ($data as $selector => $value) {
             $expectedDisplay = $expectedDisplay === null ? $value : $expectedDisplay;
             $this->findCssAndSetValue($page, $selector, $value);
@@ -490,5 +480,70 @@ class IntegrationTest extends MinkTestCase
         $this->waitForPageLoad($page);
         $this->assertEquals($expectedDisplay, $this->findCssAndGetText($page, "$listSelector a"));
         $this->assertCount($expectedLinkCount, $page->findAll('css', "$listSelector a"));
+    }
+
+    /**
+     * Assert the contents of the top and bottom controls.
+     *
+     * @param TraversableElement $page     Page being examined
+     * @param string             $expected Expected control text
+     *
+     * @return void
+     * @throws \Exception
+     */
+    protected function assertControls(TraversableElement $page, string $expected): void
+    {
+        $this->assertEquals($expected, $this->findCssAndGetText($page, '.controls.top'));
+        $this->assertEquals($expected, $this->findCssAndGetText($page, '.controls.bottom'));
+    }
+
+    /**
+     * Data provider for testCollectionBehavior().
+     *
+     * @return Generator<string, array>
+     */
+    public static function collectionBehaviorProvider(): Generator
+    {
+        yield 'default page, top buttons' => ['', '.controls.top'];
+        yield 'default page, bottom buttons' => ['', '.controls.bottom'];
+        yield 'editions view, top buttons' => ['/Editions', '.controls.top'];
+        yield 'editions view, bottom buttons' => ['/Editions', '.controls.bottom'];
+    }
+
+    /**
+     * Test collection management functionality.
+     *
+     * @param string $subPage          Subpage of item page to test.
+     * @param string $controlsSelector Selector for button bar to use for testing.
+     *
+     * @return void
+     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('collectionBehaviorProvider')]
+    public function testCollectionBehavior(string $subPage, string $controlsSelector): void
+    {
+        $page = $this->goToPage('/Item/1' . $subPage);
+        $this->assertControls($page, 'Please log in to manage your collection or post a review.');
+        $this->logIn($page, 'user');
+        // Add to all lists:
+        $this->assertControls($page, 'Submit Review Add to Have List Add to Want List Add to Sale/Trade List');
+        $this->findCss($page, $controlsSelector)->clickLink('Add to Have List');
+        $this->clickCss($page, '.content input[type="submit"]');
+        $this->assertControls($page, 'Submit Review Modify Have List Add to Want List Add to Sale/Trade List');
+        $this->findCss($page, $controlsSelector)->clickLink('Add to Want List');
+        $this->clickCss($page, '.content input[type="submit"]');
+        $this->assertControls($page, 'Submit Review Modify Have List Modify Want List Add to Sale/Trade List');
+        $this->findCss($page, $controlsSelector)->clickLink('Add to Sale/Trade List');
+        $this->clickCss($page, '.content input[type="submit"]');
+        $this->assertControls($page, 'Submit Review Modify Have List Modify Want List Modify Sale/Trade List');
+        // Remove from all lists:
+        $this->findCss($page, $controlsSelector)->clickLink('Modify Have List');
+        $this->clickCss($page, '.content input[type="submit"]', index: 1);
+        $this->assertControls($page, 'Submit Review Add to Have List Modify Want List Modify Sale/Trade List');
+        $this->findCss($page, $controlsSelector)->clickLink('Modify Want List');
+        $this->clickCss($page, '.content input[type="submit"]', index: 1);
+        $this->assertControls($page, 'Submit Review Add to Have List Add to Want List Modify Sale/Trade List');
+        $this->findCss($page, $controlsSelector)->clickLink('Modify Sale/Trade List');
+        $this->clickCss($page, '.content input[type="submit"]', index: 1);
+        $this->assertControls($page, 'Submit Review Add to Have List Add to Want List Add to Sale/Trade List');
     }
 }

--- a/module/GeebyDeeby/view/geeby-deeby/item/editions.phtml
+++ b/module/GeebyDeeby/view/geeby-deeby/item/editions.phtml
@@ -2,7 +2,58 @@
     $title = $this->fixtitle($item['Item_Name']);
     $this->layout()->title = 'Item - ' . $title;
     $this->layout()->toggleLink = $this->toggleLink('edit/item', $item['Item_ID']);
+    // --------------------------------------------------
+    // PRE-COMPUTE collection rows to set status flags.
+    //
+    // These flags are required by the "Add / Modify" buttons
+    // rendered at the top of the page.
+    // --------------------------------------------------
+    $userHasItem = $userWantsItem = $userHasExtraItem = false;
 ?>
+<?php ob_start(); ?>
+<?php if (count($owners) > 0): ?>
+  <tr class="collection-owners">
+    <th scope="row">Users Who Own This Item:</th>
+    <td>
+      <?php $prevUser = false; ?>
+      <?php foreach ($owners as $owner): $separator = $prevUser; ?><?php if ($this->auth()->hasIdentity() && $owner['User_ID'] == $this->auth()->getIdentity()): $userHasItem = true; endif; ?><?php if ($prevUser !== $owner['Username']): $prevUser = $owner['Username'];?><?php if ($separator): ?>, <?php endif; ?><a href="<?=$this->url('user', ['id' => $owner['User_ID'], 'action' => 'Collection'])?>"><?=$this->escapeHtml($prevUser)?></a><?php endif; ?><?php if (!empty($owner['Collection_Note'])): ?> (<?=$this->escapeHtml($owner['Collection_Note'])?>)<?php endif; ?><?php endforeach; ?>
+    </td>
+  </tr>
+<?php endif; ?>
+<?php $ownersRow = ob_get_clean(); ?>
+
+<?php ob_start(); ?>
+<?php if (count($buyers) > 0): ?>
+  <tr class="collection-buyers">
+    <th scope="row">Users Who Want This Item:</th>
+    <td>
+      <?php $prevUser = false; ?>
+      <?php foreach ($buyers as $buyer): $separator = $prevUser; ?><?php if ($this->auth()->hasIdentity() && $buyer['User_ID'] == $this->auth()->getIdentity()): $userWantsItem = true; endif; ?><?php if ($prevUser !== $buyer['Username']): $prevUser = $buyer['Username'];?><?php if ($separator): ?>, <?php endif; ?><a href="<?=$this->url('user', ['id' => $buyer['User_ID'], 'action' => 'Collection'])?>"><?=$this->escapeHtml($prevUser)?></a><?php endif; ?><?php if (!empty($buyer['Collection_Note'])): ?> (<?=$this->escapeHtml($buyer['Collection_Note'])?>)<?php endif; ?><?php endforeach; ?>
+    </td>
+  </tr>
+<?php endif; ?>
+<?php $buyersRow = ob_get_clean(); ?>
+
+<?php ob_start(); ?>
+<?php if (count($sellers) > 0): ?>
+  <tr class="collection-sellers">
+    <th scope="row">Users with Extra Copies:</th>
+    <td>
+      <?php $prevUser = false; ?>
+      <?php foreach ($sellers as $seller): $separator = $prevUser; ?>
+        <?php if ($this->auth()->hasIdentity() && $seller['User_ID'] == $this->auth()->getIdentity()): $userHasExtraItem = true; endif; ?>
+        <?php if ($prevUser !== $seller['Username']): $prevUser = $seller['Username'];?>
+          <?php if ($separator): ?><br /><?php endif; ?>
+          <a href="<?=$this->url('user', ['id' => $seller['User_ID'], 'action' => 'Extras'])?>">
+            <?=$this->escapeHtml($prevUser)?>
+          </a>
+        <?php endif; ?>
+        <?php if (!empty($seller['Collection_Note'])): ?> - <?=$this->escapeHtml($seller['Collection_Note'])?><?php endif; ?>
+      <?php endforeach; ?>
+    </td>
+  </tr>
+<?php endif; ?>
+<?php $sellersRow = ob_get_clean(); ?>
 <div class="row">
   <div class="col-md-12">
     <div class="controls top">
@@ -202,48 +253,7 @@
         <tr><th scope="row">Special Thanks:</th><td><?=$item['Item_Thanks']?></td></tr>
       <?php endif; ?>
 
-      <?php $userHasItem = $userWantsItem = $userHasExtraItem = false; ?>
-
-      <?php if (count($owners) > 0): ?>
-        <tr>
-          <th scope="row">Users Who Own This Item:</th>
-          <td>
-            <?php $prevUser = false; ?>
-            <?php foreach ($owners as $owner): $separator = $prevUser; ?><?php if ($this->auth()->hasIdentity() && $owner['User_ID'] == $this->auth()->getIdentity()): $userHasItem = true; endif; ?><?php if ($prevUser !== $owner['Username']): $prevUser = $owner['Username'];?><?php if ($separator): ?>, <?php endif; ?><a href="<?=$this->url('user', ['id' => $owner['User_ID'], 'action' => 'Collection'])?>"><?=$this->escapeHtml($prevUser)?></a><?php endif; ?><?php if (!empty($owner['Collection_Note'])): ?> (<?=$this->escapeHtml($owner['Collection_Note'])?>)<?php endif; ?><?php endforeach; ?>
-          </td>
-        </tr>
-      <?php endif; ?>
-
-      <?php if (count($buyers) > 0): ?>
-        <tr>
-          <th scope="row">Users Who Want This Item:</th>
-          <td>
-            <?php $prevUser = false; ?>
-            <?php foreach ($buyers as $buyer): $separator = $prevUser; ?><?php if ($this->auth()->hasIdentity() && $buyer['User_ID'] == $this->auth()->getIdentity()): $userWantsItem = true; endif; ?><?php if ($prevUser !== $buyer['Username']): $prevUser = $buyer['Username'];?><?php if ($separator): ?>, <?php endif; ?><a href="<?=$this->url('user', ['id' => $buyer['User_ID'], 'action' => 'Collection'])?>"><?=$this->escapeHtml($prevUser)?></a><?php endif; ?><?php if (!empty($buyer['Collection_Note'])): ?> (<?=$this->escapeHtml($buyer['Collection_Note'])?>)<?php endif; ?><?php endforeach; ?>
-          </td>
-        </tr>
-      <?php endif; ?>
-
-      <?php if (count($sellers) > 0): ?>
-        <tr>
-          <th scope="row">Users with Extra Copies:</th>
-          <td>
-            <?php $prevUser = false; ?>
-            <?php foreach ($sellers as $seller): $separator = $prevUser; ?>
-              <?php if ($this->auth()->hasIdentity() && $seller['User_ID'] == $this->auth()->getIdentity()): $userHasExtraItem = true; endif; ?>
-              <?php if ($prevUser !== $seller['Username']): $prevUser = $seller['Username'];?>
-                <?php if ($separator): ?><br /><?php endif; ?>
-                <a href="<?=$this->url('user', ['id' => $seller['User_ID'], 'action' => 'Extras'])?>">
-                  <?=$this->escapeHtml($prevUser)?>
-                </a>
-              <?php endif; ?>
-              <?php if (!empty($seller['Collection_Note'])): ?> - <?=$this->escapeHtml($seller['Collection_Note'])?><?php endif; ?>
-            <?php endforeach; ?>
-          </td>
-        </tr>
-      <?php endif; ?>
-
-      <?php $table_contents = ob_get_contents(); ?>
+      <?php $table_contents = ob_get_contents() . $ownersRow . $buyersRow . $sellersRow; ?>
       <?php ob_end_clean(); ?>
       <?=strlen(trim($table_contents)) > 0 ? $table_contents : 'No information available.' ?>
     </table>

--- a/module/GeebyDeeby/view/geeby-deeby/item/show.phtml
+++ b/module/GeebyDeeby/view/geeby-deeby/item/show.phtml
@@ -5,50 +5,58 @@
     $editionViewLink = $this->url('item', ['id' => $item['Item_ID'], 'extra' => 'Editions']);
 
     // --------------------------------------------------
-    // PRE-COMPUTE ownership flags for top controls ONLY
+    // PRE-COMPUTE collection rows to set status flags.
     //
     // These flags are required by the "Add / Modify" buttons
     // rendered at the top of the page.
-    //
-    // NOTE:
-    // Similar logic exists later in this file when rendering
-    // the "Users Who Own / Want / Sell" sections. That logic
-    // runs AFTER the controls are rendered, so it cannot be
-    // relied upon here.
-    //
-    // This duplication is intentional to preserve existing
-    // rendering behaviour and avoid refactoring side effects.
     // --------------------------------------------------
+    $userHasItem = $userWantsItem = $userHasExtraItem = false;
+?>
+<?php ob_start(); ?>
+<?php if (count($owners) > 0): ?>
+  <tr class="collection-owners">
+    <th scope="row">Users Who Own This Item:</th>
+    <td>
+      <?php $prevUser = false; ?>
+      <?php foreach ($owners as $owner): $separator = $prevUser; ?><?php if ($this->auth()->hasIdentity() && $owner['User_ID'] == $this->auth()->getIdentity()): $userHasItem = true; endif; ?><?php if ($prevUser !== $owner['Username']): $prevUser = $owner['Username'];?><?php if ($separator): ?>, <?php endif; ?><a href="<?=$this->url('user', ['id' => $owner['User_ID'], 'action' => 'Collection'])?>"><?=$this->escapeHtml($prevUser)?></a><?php endif; ?><?php if (!empty($owner['Collection_Note'])): ?> (<?=$this->escapeHtml($owner['Collection_Note'])?>)<?php endif; ?><?php endforeach; ?>
+    </td>
+  </tr>
+<?php endif; ?>
+<?php $ownersRow = ob_get_clean(); ?>
 
-    $userHasItem = false;
-    $userWantsItem = false;
-    $userHasExtraItem = false;
+<?php ob_start(); ?>
+<?php if (count($buyers) > 0): ?>
+  <tr class="collection-buyers">
+    <th scope="row">Users Who Want This Item:</th>
+    <td>
+      <?php $prevUser = false; ?>
+      <?php foreach ($buyers as $buyer): $separator = $prevUser; ?><?php if ($this->auth()->hasIdentity() && $buyer['User_ID'] == $this->auth()->getIdentity()): $userWantsItem = true; endif; ?><?php if ($prevUser !== $buyer['Username']): $prevUser = $buyer['Username'];?><?php if ($separator): ?>, <?php endif; ?><a href="<?=$this->url('user', ['id' => $buyer['User_ID'], 'action' => 'Collection'])?>"><?=$this->escapeHtml($prevUser)?></a><?php endif; ?><?php if (!empty($buyer['Collection_Note'])): ?> (<?=$this->escapeHtml($buyer['Collection_Note'])?>)<?php endif; ?><?php endforeach; ?>
+    </td>
+  </tr>
+<?php endif; ?>
+<?php $buyersRow = ob_get_clean(); ?>
 
-    if ($this->auth()->hasIdentity()) {
-        $uid = $this->auth()->getIdentity();
-
-        foreach (($owners ?? []) as $o) {
-            if ($o['User_ID'] == $uid) {
-                $userHasItem = true;
-                break;
-            }
-        }
-
-        foreach (($buyers ?? []) as $b) {
-            if ($b['User_ID'] == $uid) {
-                $userWantsItem = true;
-                break;
-            }
-        }
-
-        foreach (($sellers ?? []) as $s) {
-            if ($s['User_ID'] == $uid) {
-                $userHasExtraItem = true;
-                break;
-            }
-        }
-    }
-
+<?php ob_start(); ?>
+<?php if (count($sellers) > 0): ?>
+  <tr class="collection-sellers">
+    <th scope="row">Users with Extra Copies:</th>
+    <td>
+      <?php $prevUser = false; ?>
+      <?php foreach ($sellers as $seller): $separator = $prevUser; ?>
+        <?php if ($this->auth()->hasIdentity() && $seller['User_ID'] == $this->auth()->getIdentity()): $userHasExtraItem = true; endif; ?>
+        <?php if ($prevUser !== $seller['Username']): $prevUser = $seller['Username'];?>
+          <?php if ($separator): ?><br /><?php endif; ?>
+          <a href="<?=$this->url('user', ['id' => $seller['User_ID'], 'action' => 'Extras'])?>">
+            <?=$this->escapeHtml($prevUser)?>
+          </a>
+        <?php endif; ?>
+        <?php if (!empty($seller['Collection_Note'])): ?> - <?=$this->escapeHtml($seller['Collection_Note'])?><?php endif; ?>
+      <?php endforeach; ?>
+    </td>
+  </tr>
+<?php endif; ?>
+<?php $sellersRow = ob_get_clean(); ?>
+<?php
     // If there are too many images to display comfortably, pick a smaller number
     // and set a flag to display a link to edition view, where everything is visible.
     // We'll try to pick at least one image for each distinct label, to the greatest
@@ -699,44 +707,7 @@
         <tr><th scope="row">Special Thanks:</th><td><?=$item['Item_Thanks']?></td></tr>
       <?php endif; ?>
 
-      <?php if (count($owners) > 0): ?>
-        <tr>
-          <th scope="row">Users Who Own This Item:</th>
-          <td>
-            <?php $prevUser = false; ?>
-            <?php foreach ($owners as $owner): $separator = $prevUser; ?><?php if ($this->auth()->hasIdentity() && $owner['User_ID'] == $this->auth()->getIdentity()): $userHasItem = true; endif; ?><?php if ($prevUser !== $owner['Username']): $prevUser = $owner['Username'];?><?php if ($separator): ?>, <?php endif; ?><a href="<?=$this->url('user', ['id' => $owner['User_ID'], 'action' => 'Collection'])?>"><?=$this->escapeHtml($prevUser)?></a><?php endif; ?><?php if (!empty($owner['Collection_Note'])): ?> (<?=$this->escapeHtml($owner['Collection_Note'])?>)<?php endif; ?><?php endforeach; ?>
-          </td>
-        </tr>
-      <?php endif; ?>
-
-      <?php if (count($buyers) > 0): ?>
-        <tr>
-          <th scope="row">Users Who Want This Item:</th>
-          <td>
-            <?php $prevUser = false; ?>
-            <?php foreach ($buyers as $buyer): $separator = $prevUser; ?><?php if ($this->auth()->hasIdentity() && $buyer['User_ID'] == $this->auth()->getIdentity()): $userWantsItem = true; endif; ?><?php if ($prevUser !== $buyer['Username']): $prevUser = $buyer['Username'];?><?php if ($separator): ?>, <?php endif; ?><a href="<?=$this->url('user', ['id' => $buyer['User_ID'], 'action' => 'Collection'])?>"><?=$this->escapeHtml($prevUser)?></a><?php endif; ?><?php if (!empty($buyer['Collection_Note'])): ?> (<?=$this->escapeHtml($buyer['Collection_Note'])?>)<?php endif; ?><?php endforeach; ?>
-          </td>
-        </tr>
-      <?php endif; ?>
-
-      <?php if (count($sellers) > 0): ?>
-        <tr>
-          <th scope="row">Users with Extra Copies:</th>
-          <td>
-            <?php $prevUser = false; ?>
-            <?php foreach ($sellers as $seller): $separator = $prevUser; ?>
-              <?php if ($this->auth()->hasIdentity() && $seller['User_ID'] == $this->auth()->getIdentity()): $userHasExtraItem = true; endif; ?>
-              <?php if ($prevUser !== $seller['Username']): $prevUser = $seller['Username'];?>
-                <?php if ($separator): ?><br /><?php endif; ?>
-                <a href="<?=$this->url('user', ['id' => $seller['User_ID'], 'action' => 'Extras'])?>">
-                  <?=$this->escapeHtml($prevUser)?>
-                </a>
-              <?php endif; ?>
-              <?php if (!empty($seller['Collection_Note'])): ?> - <?=$this->escapeHtml($seller['Collection_Note'])?><?php endif; ?>
-            <?php endforeach; ?>
-          </td>
-        </tr>
-      <?php endif; ?>
+      <?= $ownersRow . $buyersRow . $sellersRow ?>
     </table>
   </div>
 </div>

--- a/module/GeebyDeeby/view/geeby-deeby/item/show.phtml
+++ b/module/GeebyDeeby/view/geeby-deeby/item/show.phtml
@@ -4,6 +4,51 @@
     $this->layout()->toggleLink = $this->toggleLink('edit/item', $item['Item_ID']);
     $editionViewLink = $this->url('item', ['id' => $item['Item_ID'], 'extra' => 'Editions']);
 
+    // --------------------------------------------------
+    // PRE-COMPUTE ownership flags for top controls ONLY
+    //
+    // These flags are required by the "Add / Modify" buttons
+    // rendered at the top of the page.
+    //
+    // NOTE:
+    // Similar logic exists later in this file when rendering
+    // the "Users Who Own / Want / Sell" sections. That logic
+    // runs AFTER the controls are rendered, so it cannot be
+    // relied upon here.
+    //
+    // This duplication is intentional to preserve existing
+    // rendering behaviour and avoid refactoring side effects.
+    // --------------------------------------------------
+
+    $userHasItem = false;
+    $userWantsItem = false;
+    $userHasExtraItem = false;
+
+    if ($this->auth()->hasIdentity()) {
+        $uid = $this->auth()->getIdentity();
+
+        foreach (($owners ?? []) as $o) {
+            if ($o['User_ID'] == $uid) {
+                $userHasItem = true;
+                break;
+            }
+        }
+
+        foreach (($buyers ?? []) as $b) {
+            if ($b['User_ID'] == $uid) {
+                $userWantsItem = true;
+                break;
+            }
+        }
+
+        foreach (($sellers ?? []) as $s) {
+            if ($s['User_ID'] == $uid) {
+                $userHasExtraItem = true;
+                break;
+            }
+        }
+    }
+
     // If there are too many images to display comfortably, pick a smaller number
     // and set a flag to display a link to edition view, where everything is visible.
     // We'll try to pick at least one image for each distinct label, to the greatest
@@ -653,8 +698,6 @@
       <?php if (!empty($item['Item_Thanks'])): ?>
         <tr><th scope="row">Special Thanks:</th><td><?=$item['Item_Thanks']?></td></tr>
       <?php endif; ?>
-
-      <?php $userHasItem = $userWantsItem = $userHasExtraItem = false; ?>
 
       <?php if (count($owners) > 0): ?>
         <tr>


### PR DESCRIPTION
Precompute ownership flags before rendering the top control buttons so
"Add" correctly changes to "Modify" when the user already owns, wants,
or has extras for an item.

Existing rendering logic later in the template is intentionally left
unchanged to avoid behavioural regressions.

TODO:
- [x] Close #97 when merging