### PR TITLE
Expose separate ISBN-10 and ISBN-13 links in item view

### DIFF
--- a/module/GeebyDeeby/view/geeby-deeby/item/show.phtml
+++ b/module/GeebyDeeby/view/geeby-deeby/item/show.phtml
@@ -422,14 +422,31 @@
           <th scope="row">ISBN<?=$isbnCount > 1 ? 's' : ''?>:</th>
           <td>
             <?php foreach ($isbns as $isbn => $note): ?>
-              <a href="<?=$this->url('item', ['id' => $item['Item_ID'], 'action' => 'ISBNDetails', 'extra' => $isbn])?>">
-                <?php
-                  $isbnConverter = new \VuFindCode\ISBN($isbn);
-                  $isbn10 = $isbnConverter->get10();
-                ?>
-                <?=$this->escapeHtml(!empty($isbn10) ? $isbn10 . ' / ' . $isbn : $isbn)?>
-              </a>
-              <?=!empty($note) ? '(' . $this->escapeHtml($note) . ')' : ''?>
+              <?php
+                $isbnConverter = new \VuFindCode\ISBN($isbn);
+                $isbn10 = $isbnConverter->get10();
+                $isbn13 = $isbnConverter->get13();
+              ?>
+
+              <?php if (!empty($isbn10)): ?>
+                <a href="<?=$this->url('item', [
+                    'id' => $item['Item_ID'],
+                    'action' => 'ISBNDetails',
+                    'extra' => $isbn10
+                ])?>">
+                  <?=$this->escapeHtml($isbn10)?>
+                </a>
+              <?php endif; ?><?php if (!empty($isbn10) && !empty($isbn13)): ?>/<?php endif; ?><?php if (!empty($isbn13)): ?>
+                <a href="<?=$this->url('item', [
+                    'id' => $item['Item_ID'],
+                    'action' => 'ISBNDetails',
+                    'extra' => $isbn13
+                ])?>">
+                  <?=$this->escapeHtml($isbn13)?>
+                </a>
+              <?php endif; ?>
+
+              <?=!empty($note) ? ' (' . $this->escapeHtml($note) . ')' : ''?>
               <br />
             <?php endforeach; ?>
           </td>


### PR DESCRIPTION
Previously, item pages displayed a combined ISBN string that linked only once.
This change exposes **separate ISBN-10 and ISBN-13 links** when both values
are available, allowing each identifier to be followed independently.

No database or routing changes are required; this update is limited to
presentation logic in the item view template.

TODO:
- [ ] Close #73 when merging.