### PR TITLE
Show earliest publication year in series list (Unpublished for -1)

### DIFF
--- a/module/GeebyDeeby/config/module.config.php
+++ b/module/GeebyDeeby/config/module.config.php
@@ -1425,6 +1425,8 @@ return [
                 'Laminas\ServiceManager\Factory\InvokableFactory',
             'GeebyDeeby\View\Helper\IconButton' =>
                 'Laminas\ServiceManager\Factory\InvokableFactory',
+            'GeebyDeeby\View\Helper\ItemNotes' =>
+                'Laminas\ServiceManager\Factory\InvokableFactory',
             'GeebyDeeby\View\Helper\ScriptManager' =>
                 'GeebyDeeby\View\Helper\ScriptManagerFactory',
             'GeebyDeeby\View\Helper\ShowEdition' =>
@@ -1454,6 +1456,7 @@ return [
             'groupeditions' => 'GeebyDeeby\View\Helper\GroupEditions',
             'groupEditions' => 'GeebyDeeby\View\Helper\GroupEditions',
             'iconButton' => 'GeebyDeeby\View\Helper\IconButton',
+            'itemNotes' => 'GeebyDeeby\View\Helper\ItemNotes',
             'scriptmanager' => 'GeebyDeeby\View\Helper\ScriptManager',
             'scriptManager' => 'GeebyDeeby\View\Helper\ScriptManager',
             'showedition' => 'GeebyDeeby\View\Helper\ShowEdition',

--- a/module/GeebyDeeby/src/GeebyDeeby/Db/Table/EditionsFullText.php
+++ b/module/GeebyDeeby/src/GeebyDeeby/Db/Table/EditionsFullText.php
@@ -175,6 +175,16 @@ class EditionsFullText extends Gateway
                 );
             }
             $select->join(
+                ['erd' => 'Editions_Release_Dates'],
+                'erd.Edition_ID = eds.Edition_ID',
+                [
+                    'Earliest_Year' => new Expression(
+                        'MIN(erd.Year)'
+                    ),
+                ],
+                Select::JOIN_LEFT
+            );
+            $select->join(
                 ['i' => 'Items'],
                 'eds.Item_ID = i.Item_ID'
             );

--- a/module/GeebyDeeby/src/GeebyDeeby/Db/Table/Item.php
+++ b/module/GeebyDeeby/src/GeebyDeeby/Db/Table/Item.php
@@ -149,13 +149,28 @@ class Item extends Gateway
                 ['eds' => 'Editions'],
                 'eds.Item_ID = Items.Item_ID',
                 [
-                    'Volume', 'Position', 'Replacement_Number',
+                    'Volume',
+                    'Position',
+                    'Replacement_Number',
                     'Edition_ID' => new Expression(
                         'min(?)',
                         ['eds.Edition_ID'],
                         [Expression::TYPE_IDENTIFIER]
                     ),
+                    'Earliest_Year' => new Expression(
+                        'MIN(erd.Year)'
+                    ),
                 ]
+            );
+            $select->join(
+                ['erd' => 'Editions_Release_Dates'],
+                'erd.Edition_ID = eds.Edition_ID',
+                [
+                    'Release_Year'  => 'Year',
+                    'Release_Month' => 'Month',
+                    'Release_Day'   => 'Day',
+                ],
+                Select::JOIN_LEFT
             );
             $select->join(
                 ['mt' => 'Material_Types'],

--- a/module/GeebyDeeby/src/GeebyDeeby/Db/Table/Item.php
+++ b/module/GeebyDeeby/src/GeebyDeeby/Db/Table/Item.php
@@ -157,18 +157,15 @@ class Item extends Gateway
                         ['eds.Edition_ID'],
                         [Expression::TYPE_IDENTIFIER]
                     ),
-                    'Earliest_Year' => new Expression(
-                        'MIN(erd.Year)'
-                    ),
                 ]
             );
             $select->join(
                 ['erd' => 'Editions_Release_Dates'],
                 'erd.Edition_ID = eds.Edition_ID',
                 [
-                    'Release_Year'  => 'Year',
-                    'Release_Month' => 'Month',
-                    'Release_Day'   => 'Day',
+                    'Earliest_Year' => new Expression(
+                        'MIN(erd.Year)'
+                    ),
                 ],
                 Select::JOIN_LEFT
             );

--- a/module/GeebyDeeby/src/GeebyDeeby/View/Helper/IconButton.php
+++ b/module/GeebyDeeby/src/GeebyDeeby/View/Helper/IconButton.php
@@ -30,7 +30,7 @@
 namespace GeebyDeeby\View\Helper;
 
 /**
- * Title display view helper
+ * Button view helper
  *
  * @category GeebyDeeby
  * @package  View_Helpers

--- a/module/GeebyDeeby/src/GeebyDeeby/View/Helper/ItemNotes.php
+++ b/module/GeebyDeeby/src/GeebyDeeby/View/Helper/ItemNotes.php
@@ -1,0 +1,75 @@
+<?php
+
+/**
+ * ItemNotes view helper
+ *
+ * PHP version 8
+ *
+ * Copyright (C) Demian Katz 2025.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, see
+ * <https://www.gnu.org/licenses/>.
+ *
+ * @category GeebyDeeby
+ * @package  View_Helpers
+ * @author   Demian Katz <demian.katz@villanova.edu>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://github.com/demiankatz/Geeby-Deeby Main Site
+ */
+
+namespace GeebyDeeby\View\Helper;
+
+use function count;
+
+/**
+ * ItemNotes view helper
+ *
+ * @category GeebyDeeby
+ * @package  View_Helpers
+ * @author   Demian Katz <demian.katz@villanova.edu>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://github.com/demiankatz/Geeby-Deeby Main Site
+ */
+class ItemNotes extends \Laminas\View\Helper\AbstractHelper
+{
+    /**
+     * Display parenthetical notes following an item title.
+     *
+     * @param array $item Item details
+     *
+     * @return string
+     */
+    public function __invoke($item): string
+    {
+        $escapeHtml = $this->getView()->plugin('escapeHtml');
+        $fixTitle = $this->getView()->plugin('fixtitle');
+        $itemNotes = [];
+        $earliestYear = (int)($item['Earliest_Year'] ?? 0);
+        if ($earliestYear === -1) {
+            $itemNotes[] = 'Unpublished';
+        } elseif ($earliestYear > 0) {
+            $itemNotes[] = ($escapeHtml)($item['Earliest_Year']);
+        }
+        if (!empty($item['Child_Items'])) {
+            $parts = array_unique(explode('||', $item['Child_Items']));
+            $childNote = '<i>' . ($escapeHtml)(($fixTitle)($parts[0])) . '</i>';
+            if (count($parts) == 2) {
+                $childNote .= ' and 1 more item';
+            } elseif (count($parts) > 2) {
+                $childNote .= ' and ' . (count($parts) - 1) . ' more items';
+            }
+            $itemNotes[] = $childNote;
+        }
+        return empty($itemNotes) ? '' : '(' . implode('; ', $itemNotes) . ')';
+    }
+}

--- a/module/GeebyDeeby/view/geeby-deeby/item/fulltext.phtml
+++ b/module/GeebyDeeby/view/geeby-deeby/item/fulltext.phtml
@@ -35,10 +35,7 @@
       <a href="<?=$this->url('item', ['id' => $current['Item_ID']])?>">
         <?=$this->escapeHtml($this->fixtitle(isset($current['Item_AltName']) && !empty($current['Item_AltName']) ? $current['Item_AltName'] : $current['Item_Name']))?>
       </a>
-      <?php if (!empty($current['Child_Items'])): ?>
-        <?php $parts = array_unique(explode('||', $current['Child_Items'])); ?>
-        (<i><?=$this->escapeHtml($this->fixtitle($parts[0]))?></i><?php if (count($parts) == 2): ?> and 1 more item<?php elseif (count($parts) > 2): ?> and <?=(count($parts) - 1)?> more items<?php endif;?>)
-      <?php endif; ?>
+      <?=$this->itemNotes($current)?>
       <br />
     </span>
   <?php endforeach; ?>

--- a/module/GeebyDeeby/view/geeby-deeby/item/fulltext.phtml
+++ b/module/GeebyDeeby/view/geeby-deeby/item/fulltext.phtml
@@ -33,7 +33,7 @@
     <span class="item">
       <?=$this->escapeHtml($this->formatItemNumber($current))?>
       <a href="<?=$this->url('item', ['id' => $current['Item_ID']])?>">
-        <?=$this->escapeHtml($this->fixtitle(isset($current['Item_AltName']) && !empty($current['Item_AltName']) ? $current['Item_AltName'] : $current['Item_Name']))?>
+        <?=$this->escapeHtml($this->fixtitle(!empty($current['Item_AltName']) ? $current['Item_AltName'] : $current['Item_Name']))?>
       </a>
       <?=$this->itemNotes($current)?>
       <br />

--- a/module/GeebyDeeby/view/geeby-deeby/series/show.phtml
+++ b/module/GeebyDeeby/view/geeby-deeby/series/show.phtml
@@ -170,11 +170,22 @@
     <?php endif; ?>
     <?=$this->escapeHtml($this->formatItemNumber($item))?>
     <a href="<?=$this->url('item', ['id' => $item['Item_ID']])?>">
-      <?=$this->escapeHtml($this->fixtitle(isset($item['Item_AltName']) && !empty($item['Item_AltName']) ? $item['Item_AltName'] : $item['Item_Name']))?>
+      <?=$this->escapeHtml(
+        $this->fixtitle(
+          !empty($item['Item_AltName']) ? $item['Item_AltName'] : $item['Item_Name']
+        )
+      )?>
     </a>
+    <?php if (isset($item['Earliest_Year'])): ?>
+      <?php if ((int)$item['Earliest_Year'] === -1): ?>
+        (Unpublished)
+      <?php elseif ((int)$item['Earliest_Year'] > 0): ?>
+        (<?=$this->escapeHtml($item['Earliest_Year'])?>)
+      <?php endif; ?>
+    <?php endif; ?>
     <?php if (!empty($item['Child_Items'])): ?>
       <?php $parts = array_unique(explode('||', $item['Child_Items'])); ?>
-      (<i><?=$this->escapeHtml($this->fixtitle($parts[0]))?></i><?php if (count($parts) == 2): ?> and 1 more item<?php elseif (count($parts) > 2): ?> and <?=(count($parts) - 1)?> more items<?php endif;?>)
+      (<i><?=$this->escapeHtml($this->fixtitle($parts[0]))?></i><?php if (count($parts) == 2): ?> and 1 more item<?php elseif (count($parts) > 2): ?> and <?=count($parts) - 1?> more items<?php endif;?>)
     <?php endif; ?>
     <br />
   <?php endforeach; ?>

--- a/module/GeebyDeeby/view/geeby-deeby/series/show.phtml
+++ b/module/GeebyDeeby/view/geeby-deeby/series/show.phtml
@@ -170,11 +170,7 @@
     <?php endif; ?>
     <?=$this->escapeHtml($this->formatItemNumber($item))?>
     <a href="<?=$this->url('item', ['id' => $item['Item_ID']])?>">
-      <?=$this->escapeHtml(
-        $this->fixtitle(
-            !empty($item['Item_AltName']) ? $item['Item_AltName'] : $item['Item_Name']
-        )
-      )?>
+      <?=$this->escapeHtml($this->fixtitle(!empty($item['Item_AltName']) ? $item['Item_AltName'] : $item['Item_Name']))?>
     </a>
     <?=$this->itemNotes($item)?>
     <br />

--- a/module/GeebyDeeby/view/geeby-deeby/series/show.phtml
+++ b/module/GeebyDeeby/view/geeby-deeby/series/show.phtml
@@ -172,21 +172,11 @@
     <a href="<?=$this->url('item', ['id' => $item['Item_ID']])?>">
       <?=$this->escapeHtml(
         $this->fixtitle(
-          !empty($item['Item_AltName']) ? $item['Item_AltName'] : $item['Item_Name']
+            !empty($item['Item_AltName']) ? $item['Item_AltName'] : $item['Item_Name']
         )
       )?>
     </a>
-    <?php if (isset($item['Earliest_Year'])): ?>
-      <?php if ((int)$item['Earliest_Year'] === -1): ?>
-        (Unpublished)
-      <?php elseif ((int)$item['Earliest_Year'] > 0): ?>
-        (<?=$this->escapeHtml($item['Earliest_Year'])?>)
-      <?php endif; ?>
-    <?php endif; ?>
-    <?php if (!empty($item['Child_Items'])): ?>
-      <?php $parts = array_unique(explode('||', $item['Child_Items'])); ?>
-      (<i><?=$this->escapeHtml($this->fixtitle($parts[0]))?></i><?php if (count($parts) == 2): ?> and 1 more item<?php elseif (count($parts) > 2): ?> and <?=count($parts) - 1?> more items<?php endif;?>)
-    <?php endif; ?>
+    <?=$this->itemNotes($item)?>
     <br />
   <?php endforeach; ?>
 <?php endif; ?>


### PR DESCRIPTION
This change adds a publication indicator to items listed on a series page.

For each item, the earliest known publication year is displayed in parentheses after the title.
If the earliest year is -1, the item is shown as "Unpublished" instead.

The intent is to make series lists easier to scan while avoiding clutter from multiple release dates.

Summary of changes:
- Determine the earliest publication year per item at query time
- Display the year inline in the series item list
- Render -1 as "Unpublished"
- Leave items with no publication data unchanged

Files changed:
- module/GeebyDeeby/src/GeebyDeeby/Db/Table/Item.php
- module/GeebyDeeby/view/geeby-deeby/series/show.phtml

Notes:
- Only the earliest year is shown (no month or day)
- Changes are limited to series item listings
- No database schema changes

Closes #56