### PR TITLE
Add search result details for series year, language, and item count

### DIFF
--- a/module/GeebyDeeby/src/GeebyDeeby/Db/Service/SeriesCategoryService.php
+++ b/module/GeebyDeeby/src/GeebyDeeby/Db/Service/SeriesCategoryService.php
@@ -30,6 +30,8 @@
 namespace GeebyDeeby\Db\Service;
 
 use GeebyDeeby\Db\Entity\Category;
+use GeebyDeeby\Db\Entity\EditionsReleaseDate;
+use GeebyDeeby\Db\Entity\Edition;
 use GeebyDeeby\Db\Entity\Series;
 use GeebyDeeby\Db\Entity\SeriesCategory;
 use GeebyDeeby\Db\Entity\SeriesCategoryEntityInterface;
@@ -67,9 +69,14 @@ class SeriesCategoryService extends AbstractDbService
      */
     public function getSeriesForCategory(int $categoryID): array
     {
-        $dql = 'SELECT s FROM ' . SeriesCategory::class . ' sc '
+        $dql = 'SELECT MIN(erdFiltered.year) AS Earliest_Year, s.id AS Series_ID, s.seriesName AS Series_Name FROM '
+            . SeriesCategory::class . ' sc '
             . 'INNER JOIN ' . Series::class . ' s ON sc.series=s.id '
-            . 'WHERE sc.category=:category ORDER BY s.seriesName';
+            . 'LEFT JOIN ' . Edition::class . ' e ON e.series=s.id '
+            . 'LEFT JOIN ' . EditionsReleaseDate::class . ' erdFiltered ON e.id=erdFiltered.edition '
+            . 'AND erdFiltered.year > 0 '
+            . 'WHERE sc.category=:category '
+            . 'GROUP BY s.id, s.seriesName ORDER BY s.seriesName';
         $query = $this->entityManager->createQuery($dql);
         $query->setParameter('category', $categoryID);
         return $query->getResult();

--- a/module/GeebyDeeby/src/GeebyDeeby/Db/Service/SeriesService.php
+++ b/module/GeebyDeeby/src/GeebyDeeby/Db/Service/SeriesService.php
@@ -34,6 +34,8 @@ use Doctrine\DBAL\Query\UnionType;
 use Doctrine\ORM\Tools\Pagination\Paginator as PaginationPaginator;
 use GeebyDeeby\Db\DoctrinePaginatorAdapter;
 use GeebyDeeby\Db\Entity\Edition;
+use GeebyDeeby\Db\Entity\EditionsReleaseDate;
+use GeebyDeeby\Db\Entity\Language;
 use GeebyDeeby\Db\Entity\Item;
 use GeebyDeeby\Db\Entity\Series;
 use GeebyDeeby\Db\Entity\SeriesAltTitle;
@@ -158,8 +160,17 @@ class SeriesService extends AbstractDbService
     public function keywordSearch(array $tokens): array
     {
         $where = array_map(fn ($i) => 's.seriesName LIKE ?' . $i, array_keys($tokens));
-        $dql = 'SELECT s.id AS Series_ID, s.seriesName AS Series_Name FROM ' . Series::class . ' s WHERE '
-            . implode(' AND ', $where) . ' ORDER BY s.seriesName';
+        $dql = 'SELECT MIN(erdFiltered.year) AS Earliest_Year, COUNT(DISTINCT i.id) AS Item_Count, '
+            . 's.id AS Series_ID, s.seriesName AS Series_Name, l.id AS Language_ID, l.languageName AS Language_Name '
+            . 'FROM '
+            . Series::class . ' s '
+            . 'INNER JOIN ' . Language::class . ' l ON s.language=l.id '
+            . 'LEFT JOIN ' . Edition::class . ' e ON e.series=s.id '
+            . 'LEFT JOIN ' . Item::class . ' i ON e.item=i.id '
+            . 'LEFT JOIN ' . EditionsReleaseDate::class . ' erdFiltered ON e.id=erdFiltered.edition '
+            . 'AND erdFiltered.year > 0 '
+            . 'WHERE ' . implode(' AND ', $where) . ' '
+            . 'GROUP BY s.id, s.seriesName, l.id, l.languageName ORDER BY s.seriesName';
         $query = $this->entityManager->createQuery($dql);
         $query->setParameters(array_map(fn ($token) => "%$token%", $tokens));
         return $query->getResult();

--- a/module/GeebyDeeby/view/geeby-deeby/category/index.phtml
+++ b/module/GeebyDeeby/view/geeby-deeby/category/index.phtml
@@ -21,8 +21,14 @@
         <h2><?=$this->escapeHtml($currentLetter)?><a href="#" style="float:right">Back to Top &uarr;</a></h2>
       <?php endif; ?>
     <?php endif; ?>
-    <a href="<?=$this->url('series', ['id' => $current['Series_ID']])?>">
-      <?=$this->escapeHtml($this->fixtitle($current['Series_Name']))?>
-    </a><br />
+    <?php if (!empty($current['Earliest_Year'])): ?>
+      <a href="<?=$this->url('series', ['id' => $current['Series_ID']])?>">
+        <?=$this->escapeHtml($this->fixtitle($current['Series_Name']))?>
+      </a> <span class="series-year">(<?=$this->escapeHtml($current['Earliest_Year'])?>)</span><br />
+    <?php else: ?>
+      <a href="<?=$this->url('series', ['id' => $current['Series_ID']])?>">
+        <?=$this->escapeHtml($this->fixtitle($current['Series_Name']))?>
+      </a><br />
+    <?php endif; ?>
   <?php endforeach; ?>
 <?php endif; ?>

--- a/module/GeebyDeeby/view/geeby-deeby/search/controls.phtml
+++ b/module/GeebyDeeby/view/geeby-deeby/search/controls.phtml
@@ -1,6 +1,7 @@
 <?php $config = $this->config('search_controls') ?? []; ?>
 <div class="results row">
   <ul class="search-controls hidden">
+    <li><label><input class="series-details-toggle" type="checkbox" /> Show details</label></li>
     <li><label><input class="creator-toggle" type="checkbox" /> Show credits</label></li>
     <?php foreach ($config['edition_attributes'] ?? [] as $id => $label): ?>
       <li><label><input class="edition-attribute-toggle" data-edition-attribute-id="<?=$id?>" type="checkbox" /> <?=$this->escapeHtml($label)?></label></li>

--- a/module/GeebyDeeby/view/geeby-deeby/search/list.phtml
+++ b/module/GeebyDeeby/view/geeby-deeby/search/list.phtml
@@ -7,6 +7,25 @@
         <a href="<?=$this->url(strtolower($this->prefix), ['id' => $current[$this->prefix . '_ID']])?>">
           <?=$this->escapeHtml($this->fixtitle($current[$this->prefix . '_Name'] ?? $current[$this->prefix . '_AltName']))?>
         </a>
+        <?php if ($this->prefix === 'Series'): ?>
+          <?php
+            $details = [];
+            if (!empty($current['Earliest_Year'])) {
+                $details[] = $current['Earliest_Year'];
+            }
+            if (!empty($current['Language_Name'])) {
+                $details[] = $current['Language_Name'];
+            }
+            if (isset($current['Item_Count'])) {
+                $details[] = $current['Item_Count'] . ' ' . ($current['Item_Count'] == 1 ? 'item' : 'items');
+            }
+          ?>
+          <?php if (count($details) > 0): ?>
+            <div class="hidden series-details" data-loaded="1" data-item-id="<?=$current[$this->prefix . '_ID']?>">
+              <span class="values"><?= $this->escapeHtml(implode(', ', $details)) ?></span>
+            </div>
+          <?php endif; ?>
+        <?php endif; ?>
         <?php if ($this->prefix === 'Item'): ?>
           <div class="hidden creators" data-loaded="0" data-item-id="<?=$current[$this->prefix . '_ID']?>">
             <span class="values"></span>

--- a/public/css/geeby-deeby.css
+++ b/public/css/geeby-deeby.css
@@ -220,6 +220,10 @@ ul.search-controls li,
 ul.person-full-text li {
   list-style-type: none;
 }
+ul.search-controls li {
+  display: inline-block;
+  margin-right: 1rem;
+}
 
 .item-image {
   max-width: 100%;

--- a/public/js/search.js
+++ b/public/js/search.js
@@ -3,6 +3,22 @@ function setupSearch() {
     document.querySelectorAll('.search-controls').forEach((element) => {
         element.classList.remove('hidden');
     });
+    document.querySelectorAll('.series-details-toggle').forEach((element) => {
+        let detailsVisible = sessionStorage.getItem("series_details_visible") === "1";
+        if (detailsVisible) {
+            document.querySelectorAll('.series-details').forEach((element) => {
+                element.classList.remove('hidden');
+            });
+            element.checked = true;
+        }
+        element.addEventListener('change', (event) => {
+            detailsVisible = element.checked;
+            sessionStorage.setItem("series_details_visible", detailsVisible ? "1" : "0");
+            document.querySelectorAll('.series-details').forEach((element) => {
+                element.classList.toggle('hidden', !detailsVisible);
+            });
+        });
+    });
     document.querySelectorAll('.creator-toggle').forEach((element) => {
         let creatorsVisible = sessionStorage.getItem("creators_visible") === "1";
         let creatorsLoading = false;

--- a/tatus --short --branch
+++ b/tatus --short --branch
@@ -1,0 +1,113 @@
+warning: in the working copy of 'module/GeebyDeeby/src/GeebyDeeby/Db/Service/SeriesCategoryService.php', LF will be replaced by CRLF the next time Git touches it
+warning: in the working copy of 'module/GeebyDeeby/src/GeebyDeeby/Db/Service/SeriesService.php', LF will be replaced by CRLF the next time Git touches it
+warning: in the working copy of 'module/GeebyDeeby/view/geeby-deeby/category/index.phtml', LF will be replaced by CRLF the next time Git touches it
+warning: in the working copy of 'module/GeebyDeeby/view/geeby-deeby/search/controls.phtml', LF will be replaced by CRLF the next time Git touches it
+warning: in the working copy of 'module/GeebyDeeby/view/geeby-deeby/search/list.phtml', LF will be replaced by CRLF the next time Git touches it
+warning: in the working copy of 'public/css/geeby-deeby.css', LF will be replaced by CRLF the next time Git touches it
+warning: in the working copy of 'public/js/search.js', LF will be replaced by CRLF the next time Git touches it
+[1mdiff --git a/module/GeebyDeeby/src/GeebyDeeby/Db/Service/SeriesCategoryService.php b/module/GeebyDeeby/src/GeebyDeeby/Db/Service/SeriesCategoryService.php[m
+[1mindex b2add8e6..c4869533 100644[m
+[1m--- a/module/GeebyDeeby/src/GeebyDeeby/Db/Service/SeriesCategoryService.php[m
+[1m+++ b/module/GeebyDeeby/src/GeebyDeeby/Db/Service/SeriesCategoryService.php[m
+[36m@@ -30,6 +30,8 @@[m
+ namespace GeebyDeeby\Db\Service;[m
+ [m
+ use GeebyDeeby\Db\Entity\Category;[m
+[32m+[m[32muse GeebyDeeby\Db\Entity\EditionsReleaseDate;[m
+[32m+[m[32muse GeebyDeeby\Db\Entity\Edition;[m
+ use GeebyDeeby\Db\Entity\Series;[m
+ use GeebyDeeby\Db\Entity\SeriesCategory;[m
+ use GeebyDeeby\Db\Entity\SeriesCategoryEntityInterface;[m
+[36m@@ -67,9 +69,14 @@[m [mclass SeriesCategoryService extends AbstractDbService[m
+      */[m
+     public function getSeriesForCategory(int $categoryID): array[m
+     {[m
+[31m-        $dql = 'SELECT s FROM ' . SeriesCategory::class . ' sc '[m
+[32m+[m[32m        $dql = 'SELECT MIN(erdFiltered.year) AS Earliest_Year, s.id AS Series_ID, s.seriesName AS Series_Name FROM '[m
+[32m+[m[32m            . SeriesCategory::class . ' sc '[m
+             . 'INNER JOIN ' . Series::class . ' s ON sc.series=s.id '[m
+[31m-            . 'WHERE sc.category=:category ORDER BY s.seriesName';[m
+[32m+[m[32m            . 'LEFT JOIN ' . Edition::class . ' e ON e.series=s.id '[m
+[32m+[m[32m            . 'LEFT JOIN ' . EditionsReleaseDate::class . ' erdFiltered ON e.id=erdFiltered.edition '[m
+[32m+[m[32m            . 'AND erdFiltered.year > 0 '[m
+[32m+[m[32m            . 'WHERE sc.category=:category '[m
+[32m+[m[32m            . 'GROUP BY s.id, s.seriesName ORDER BY s.seriesName';[m
+         $query = $this->entityManager->createQuery($dql);[m
+         $query->setParameter('category', $categoryID);[m
+         return $query->getResult();[m
+[1mdiff --git a/module/GeebyDeeby/src/GeebyDeeby/Db/Service/SeriesService.php b/module/GeebyDeeby/src/GeebyDeeby/Db/Service/SeriesService.php[m
+[1mindex 664c84d0..41b62dc6 100644[m
+[1m--- a/module/GeebyDeeby/src/GeebyDeeby/Db/Service/SeriesService.php[m
+[1m+++ b/module/GeebyDeeby/src/GeebyDeeby/Db/Service/SeriesService.php[m
+[36m@@ -34,6 +34,8 @@[m [muse Doctrine\DBAL\Query\UnionType;[m
+ use Doctrine\ORM\Tools\Pagination\Paginator as PaginationPaginator;[m
+ use GeebyDeeby\Db\DoctrinePaginatorAdapter;[m
+ use GeebyDeeby\Db\Entity\Edition;[m
+[32m+[m[32muse GeebyDeeby\Db\Entity\EditionsReleaseDate;[m
+[32m+[m[32muse GeebyDeeby\Db\Entity\Language;[m
+ use GeebyDeeby\Db\Entity\Item;[m
+ use GeebyDeeby\Db\Entity\Series;[m
+ use GeebyDeeby\Db\Entity\SeriesAltTitle;[m
+[36m@@ -158,8 +160,17 @@[m [mclass SeriesService extends AbstractDbService[m
+     public function keywordSearch(array $tokens): array[m
+     {[m
+         $where = array_map(fn ($i) => 's.seriesName LIKE ?' . $i, array_keys($tokens));[m
+[31m-        $dql = 'SELECT s.id AS Series_ID, s.seriesName AS Series_Name FROM ' . Series::class . ' s WHERE '[m
+[31m-            . implode(' AND ', $where) . ' ORDER BY s.seriesName';[m
+[32m+[m[32m        $dql = 'SELECT MIN(erdFiltered.year) AS Earliest_Year, COUNT(DISTINCT i.id) AS Item_Count, '[m
+[32m+[m[32m            . 's.id AS Series_ID, s.seriesName AS Series_Name, l.id AS Language_ID, l.languageName AS Language_Name '[m
+[32m+[m[32m            . 'FROM '[m
+[32m+[m[32m            . Series::class . ' s '[m
+[32m+[m[32m            . 'INNER JOIN ' . Language::class . ' l ON s.language=l.id '[m
+[32m+[m[32m            . 'LEFT JOIN ' . Edition::class . ' e ON e.series=s.id '[m
+[32m+[m[32m            . 'LEFT JOIN ' . Item::class . ' i ON e.item=i.id '[m
+[32m+[m[32m            . 'LEFT JOIN ' . EditionsReleaseDate::class . ' erdFiltered ON e.id=erdFiltered.edition '[m
+[32m+[m[32m            . 'AND erdFiltered.year > 0 '[m
+[32m+[m[32m            . 'WHERE ' . implode(' AND ', $where) . ' '[m
+[32m+[m[32m            . 'GROUP BY s.id, s.seriesName, l.id, l.languageName ORDER BY s.seriesName';[m
+         $query = $this->entityManager->createQuery($dql);[m
+         $query->setParameters(array_map(fn ($token) => "%$token%", $tokens));[m
+         return $query->getResult();[m
+[1mdiff --git a/module/GeebyDeeby/view/geeby-deeby/category/index.phtml b/module/GeebyDeeby/view/geeby-deeby/category/index.phtml[m
+[1mindex 7c2eb58a..6ad22ef9 100644[m
+[1m--- a/module/GeebyDeeby/view/geeby-deeby/category/index.phtml[m
+[1m+++ b/module/GeebyDeeby/view/geeby-deeby/category/index.phtml[m
+[36m@@ -21,8 +21,14 @@[m
+         <h2><?=$this->escapeHtml($currentLetter)?><a href="#" style="float:right">Back to Top &uarr;</a></h2>[m
+       <?php endif; ?>[m
+     <?php endif; ?>[m
+[31m-    <a href="<?=$this->url('series', ['id' => $current['Series_ID']])?>">[m
+[31m-      <?=$this->escapeHtml($this->fixtitle($current['Series_Name']))?>[m
+[31m-    </a><br />[m
+[32m+[m[32m    <?php if (!empty($current['Earliest_Year'])): ?>[m
+[32m+[m[32m      <a href="<?=$this->url('series', ['id' => $current['Series_ID']])?>">[m
+[32m+[m[32m        <?=$this->escapeHtml($this->fixtitle($current['Series_Name']))?>[m
+[32m+[m[32m      </a> <span class="series-year">(<?=$this->escapeHtml($current['Earliest_Year'])?>)</span><br />[m
+[32m+[m[32m    <?php else: ?>[m
+[32m+[m[32m      <a href="<?=$this->url('series', ['id' => $current['Series_ID']])?>">[m
+[32m+[m[32m        <?=$this->escapeHtml($this->fixtitle($current['Series_Name']))?>[m
+[32m+[m[32m      </a><br />[m
+[32m+[m[32m    <?php endif; ?>[m
+   <?php endforeach; ?>[m
+[31m-<?php endif; ?>[m
+\ No newline at end of file[m
+[32m+[m[32m<?php endif; ?>[m
+[1mdiff --git a/module/GeebyDeeby/view/geeby-deeby/search/controls.phtml b/module/GeebyDeeby/view/geeby-deeby/search/controls.phtml[m
+[1mindex 889e2cab..dc8ac378 100644[m
+[1m--- a/module/GeebyDeeby/view/geeby-deeby/search/controls.phtml[m
+[1m+++ b/module/GeebyDeeby/view/geeby-deeby/search/controls.phtml[m
+[36m@@ -1,6 +1,7 @@[m
+ <?php $config = $this->config('search_controls') ?? []; ?>[m
+ <div class="results row">[m
+   <ul class="search-controls hidden">[m
+[32m+[m[32m    <li><label><input class="series-details-toggle" type="checkbox" /> Show details</label></li>[m
+     <li><label><input class="creator-toggle" type="checkbox" /> Show credits</label></li>[m
+     <?php foreach ($config['edition_attributes'] ?? [] as $id => $label): ?>[m
+       <li><label><input class="edition-attribute-toggle" data-edition-attribute-id="<?=$id?>" type="checkbox" /> <?=$this->escapeHtml($label)?></label></li>[m
+[1mdiff --git a/module/GeebyDeeby/view/geeby-deeby/search/list.phtml b/module/GeebyDeeby/view/geeby-deeby/search/list.phtml[m
+[1mindex cfd68b92..1e82818c 100644[m
+[1m--- a/module/GeebyDeeby/view/geeby-deeby/search/list.phtml[m
+[1m+++ b/module/GeebyDeeby/view/geeby-deeby/search/list.phtml[m
+[36m@@ -7,6 +7,25 @@[m
+         <a href="<?=$this->url(strtolower($this->prefix), ['id' => $current[$this->prefix . '_ID']])?>">[m
+           <?=$this->escapeHtml($this->fixtitle($current[$this->prefix . '_Name'] ?? $current[$this->prefix . 


### PR DESCRIPTION
Added a Show details checkbox to the search results page, alongside Show credits. When enabled, additional metadata is displayed beneath each series title, including the earliest release year, language, and number of items in the series.
  
<img width="916" height="505" alt="image" src="https://github.com/user-attachments/assets/e53b95f3-5ad8-420a-8d03-487691e11987" />

Also added the earliest release year in parentheses after series titles on the Categories pages.

<img width="829" height="552" alt="image" src="https://github.com/user-attachments/assets/e572af79-88be-404f-a77e-abf03eed57f5" />
