### PR TITLE
Add user collection CSV exports and qualify review approval filters

### DIFF
--- a/module/GeebyDeeby/src/GeebyDeeby/Controller/UserController.php
+++ b/module/GeebyDeeby/src/GeebyDeeby/Controller/UserController.php
@@ -32,6 +32,8 @@ namespace GeebyDeeby\Controller;
 use GeebyDeeby\Crypt\PasswordHasher;
 
 use function is_object;
+use function preg_replace;
+use function strtolower;
 
 /**
  * User controller
@@ -88,6 +90,68 @@ class UserController extends AbstractBase
         $view->collection = $formatted;
         $view->seriesNames = $seriesNames;
         return $view;
+    }
+
+    /**
+     * Export a user's collection list as CSV.
+     *
+     * @param string $status Collection status to export.
+     * @param string $suffix  File suffix to use in the download name.
+     *
+     * @return mixed
+     */
+    protected function exportCollectionAction($status, $suffix)
+    {
+        $view = $this->getViewModelWithUser();
+        if (!$view) {
+            return $this->forwardTo(__NAMESPACE__ . '\User', 'notfound');
+        }
+
+        $rows = $this->getDbTable('collections')->getForUser(
+            $view->user['User_ID'],
+            $status,
+            true
+        );
+
+        $csv = [];
+        $csv[] = ['Series', 'Position', 'Item', 'Comment'];
+
+        foreach ($rows as $current) {
+            $itemTitle = empty($current['Item_AltName'])
+                ? $current['Item_Name']
+                : $current['Item_AltName'];
+            $csv[] = [
+                $this->serviceLocator->get('GeebyDeeby\Articles')
+                    ->formatTrailingArticles($current['Series_Name'] ?? ''),
+                $current['Position'] ?? '',
+                $this->serviceLocator->get('GeebyDeeby\Articles')
+                    ->formatTrailingArticles($itemTitle),
+                $current['Collection_Note'] ?? '',
+            ];
+        }
+
+        $output = fopen('php://temp', 'r+');
+        foreach ($csv as $row) {
+            fputcsv($output, $row);
+        }
+        rewind($output);
+        $csv = stream_get_contents($output);
+        fclose($output);
+
+        $filename = preg_replace(
+            '/[^A-Za-z0-9_-]+/',
+            '_',
+            strtolower($view->user['Username'] . '-' . $suffix . '-list')
+        );
+        $response = $this->getResponse();
+        $headers = $response->getHeaders();
+        $headers->addHeaderLine('Content-Type', 'text/csv; charset=UTF-8');
+        $headers->addHeaderLine(
+            'Content-Disposition',
+            'attachment; filename="' . $filename . '.csv"'
+        );
+        $response->setContent("\xEF\xBB\xBF" . $csv);
+        return $response;
     }
 
     /**
@@ -210,6 +274,16 @@ class UserController extends AbstractBase
     }
 
     /**
+     * Export the items on a user's have list.
+     *
+     * @return mixed
+     */
+    public function exporthaveAction()
+    {
+        return $this->exportCollectionAction('have', 'have');
+    }
+
+    /**
      * "Show user" page
      *
      * @return mixed
@@ -227,6 +301,16 @@ class UserController extends AbstractBase
         $view->reviews = $this->getDbTable('itemsreviews')
             ->getReviewIDsByUser($view->user['User_ID']);
         return $view;
+    }
+
+    /**
+     * Export the items on a user's want list.
+     *
+     * @return mixed
+     */
+    public function exportwantAction()
+    {
+        return $this->exportCollectionAction('want', 'want');
     }
 
     /**

--- a/module/GeebyDeeby/src/GeebyDeeby/Db/Table/ItemsReviews.php
+++ b/module/GeebyDeeby/src/GeebyDeeby/Db/Table/ItemsReviews.php
@@ -85,7 +85,7 @@ class ItemsReviews extends Gateway
                 'Items_Reviews.User_ID = u.User_ID'
             );
             if (null !== $approved) {
-                $select->where->equalTo('Approved', $approved);
+                $select->where->equalTo('Items_Reviews.Approved', $approved);
             }
             $select->where->equalTo('Item_ID', $itemID);
         };
@@ -105,7 +105,7 @@ class ItemsReviews extends Gateway
     {
         $callback = function ($select) use ($userID, $approved): void {
             if (null !== $approved) {
-                $select->where->equalTo('Approved', $approved);
+                $select->where->equalTo('Items_Reviews.Approved', $approved);
             }
             $select->where->equalTo('User_ID', $userID);
         };
@@ -205,7 +205,7 @@ class ItemsReviews extends Gateway
             ];
             $select->order($series ? $all : ['Item_Name']);
             if (null !== $approved) {
-                $select->where->equalTo('Approved', $approved);
+                $select->where->equalTo('Items_Reviews.Approved', $approved);
             }
             if (null !== $userID) {
                 $select->where->equalTo('User_ID', $userID);

--- a/module/GeebyDeeby/src/GeebyDeeby/Db/Table/SeriesReviews.php
+++ b/module/GeebyDeeby/src/GeebyDeeby/Db/Table/SeriesReviews.php
@@ -83,7 +83,7 @@ class SeriesReviews extends Gateway
                 'Series_Reviews.User_ID = u.User_ID'
             );
             if (null !== $approved) {
-                $select->where->equalTo('Approved', $approved);
+                $select->where->equalTo('Series_Reviews.Approved', $approved);
             }
             $select->where->equalTo('Series_ID', $seriesID);
         };
@@ -118,7 +118,7 @@ class SeriesReviews extends Gateway
                 ['Series_Name', 's.Series_ID']
             );
             if (null !== $approved) {
-                $select->where->equalTo('Approved', $approved);
+                $select->where->equalTo('Series_Reviews.Approved', $approved);
             }
             if (null !== $userID) {
                 $select->where->equalTo('User_ID', $userID);

--- a/module/GeebyDeeby/view/geeby-deeby/user/index.phtml
+++ b/module/GeebyDeeby/view/geeby-deeby/user/index.phtml
@@ -10,6 +10,12 @@
       <a class="button" href="<?=$this->url('user', ['id' => $user['User_ID'], 'extra' => 'Edit'])?>">
         Edit Account Details
       </a>
+      <a class="button" href="<?=$this->url('user', ['id' => $user['User_ID'], 'action' => 'ExportHave'])?>">
+        Export Have List
+      </a>
+      <a class="button" href="<?=$this->url('user', ['id' => $user['User_ID'], 'action' => 'ExportWant'])?>">
+        Export Want List
+      </a>
     </p>
     <?php $controls = ob_get_flush(); ?>
   </div>


### PR DESCRIPTION
<img width="801" height="359" alt="image" src="https://github.com/user-attachments/assets/a96f1945-4274-4302-ae4e-d401d151de8c" />

<img width="675" height="114" alt="image" src="https://github.com/user-attachments/assets/bf43257a-8fba-450a-bd0c-fdaab08d82fe" />


Added Export Have List and Export Want List buttons to the top control row on the user page, with CSV download actions for both lists. The exported CSV includes Series, Position, Item, and Comment, with Position using the raw item position value rather than the display-formatted “no. X” text, and Comment containing the user’s collection note. Also qualified the Approved field in review table queries to avoid SQL ambiguity when the Users table is joined; this fix applies to both item and series review queries.